### PR TITLE
Fixes inhibitor errors

### DIFF
--- a/src/events/commandInhibited.js
+++ b/src/events/commandInhibited.js
@@ -3,7 +3,13 @@ const { Event } = require('klasa');
 module.exports = class extends Event {
 
 	run(message, command, response) {
-		if (response && response.length) message.channel.send(response);
+		if (response && response.length) {
+			if (Array.isArray(response)) {
+				message.channel.send({ content: response.join('\n') });
+			} else {
+				message.channel.send({ content: response });
+			}
+		}
 	}
 
 };


### PR DESCRIPTION
Inhibitor errors are thrown from commandHandler in OSB in the form of an array, which is no longer supported by channel.send(). 

I consiered updating OSB, however I feel this should be in Klasa because it had always worked in the past, and we're just updating the engine to work with the new discord.js version.

Yes I tested it.... i spent hours and hours working on it for this simple solution XD. Learned even more about how klasa works internally though, which is nice.