### PR TITLE
Make eval work on node16

### DIFF
--- a/src/lib/util/Type.js
+++ b/src/lib/util/Type.js
@@ -1,5 +1,3 @@
-const { getPromiseDetails } = process.binding('util');
-
 /**
  * The class for deep checking Types
  */
@@ -114,9 +112,7 @@ class Type {
 	 */
 	check() {
 		if (Object.isFrozen(this)) return;
-		const promise = getPromiseDetails(this.value);
 		if (typeof this.value === 'object' && this.isCircular()) this.is = `[Circular:${this.is}]`;
-		else if (promise && promise[0]) this.addValue(promise[1]);
 		else if (this.value instanceof Map) for (const entry of this.value) this.addEntry(entry);
 		else if (Array.isArray(this.value) || this.value instanceof Set) for (const value of this.value) this.addValue(value);
 		else if (this.is === 'Object') this.is = 'any';


### PR DESCRIPTION
This patch enables eval to work on Node 16 where the getPromiseDetails() internal/undocumented function no longer exists.

Have tested it thoroughly