### PR TITLE
Fix issue where first command per guild fails

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -181,7 +181,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_customPrefix() {
-			const settings = this.guild.client.gateways.get('guilds').get(this.guild.id);
+			const settings = this.guild.client.gateways.get('guilds').acquire(this.guild.id);
 			if (!settings) return null;
 			const prefix = settings.get('prefix');
 			if (!prefix || !prefix.length) return null;


### PR DESCRIPTION
The first command given in any server shortly after a restart will fail because the cache is not yet loaded, and _customPrefix() is using Gateway.get() instead of Gateway.acquire().

This updates the behavior to use acquire, which creates the Settings cache and loads (syncs) the data from the DB.

Tested.

Update: This is superseded by https://github.com/gc/klasa/pull/8
Please merge #8 and not this