### PR TITLE
Fix direct message usage, and initialize cache

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -181,7 +181,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_customPrefix() {
-			const settings = this.guild.client.gateways.get('guilds').get(this.guild.id);
+			const settings = this.guild ? this.guild.client.gateways.get('guilds').acquire(this.guild.id) : this.client.gateways.get('guilds').schema.defaults;
 			if (!settings) return null;
 			const prefix = settings.get('prefix');
 			if (!prefix || !prefix.length) return null;


### PR DESCRIPTION
This fixes an issue where Direct Messages to the bot were broken from the last Klasa cleanup.

It also uses acquire instead of get, otherwise the first command in a guild will always fail because the cache isn't yet loaded.

Code has been tested 