### PR TITLE
Fix first command in a guild failing

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -181,7 +181,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_customPrefix() {
-			const settings = this.guild ? this.guild.client.gateways.get('guilds').get(this.guild.id) : this.client.gateways.get('guilds').schema.defaults;
+			const settings = this.guild ? this.guild.client.gateways.get('guilds').acquire(this.guild.id) : this.client.gateways.get('guilds').schema.defaults;
 			if (!settings) return null;
 			const prefix = settings.get('prefix');
 			if (!prefix || !prefix.length) return null;


### PR DESCRIPTION
As the customPrefix code is some of the first code that's run when a command comes in from a new guild, the Settings object must be 'acquired' from the gateway so that it's initialized from the DB, otherwise the `.get()` method just fails and returns null because there is no matching initialized/created Settings object.

I have tested this, it  works :D