### PR TITLE
BUG! Fix custom prefix fail.

### DIFF
--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -181,7 +181,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_customPrefix() {
-			const settings = this.guild ? this.guild.client.gateways.get('guilds').acquire(this.guild.id) : this.client.gateways.get('guilds').schema.defaults;
+			const settings = this.guild ? this.guild.client.gateways.get('guilds').acquire(this.guild) : this.client.gateways.get('guilds').schema.defaults;
 			if (!settings) return null;
 			const prefix = settings.get('prefix');
 			if (!prefix || !prefix.length) return null;


### PR DESCRIPTION
Custom prefix's fail altogether because I passed wrong variable to acquire, oops.

This fixes that.  But still doesn't work any better than just using .get().

_**This is needed or else all custom prefixes will fail.**_ 

I spent a lot of time on this one, lol. (obviously don't have a total solution yet). Details in your PM.