### PR TITLE
Fix Klasa guild cache

### DIFF
--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -24,11 +24,12 @@ module.exports = class extends Event {
 
 		// Initialize guild cache:
 		const guildsGateway = this.client.gateways.get('guilds');
-		const waitForSync = this.client.guilds.cache.map(guild => {
-			const settings = guildsGateway.acquire(guild);
-			return settings.sync(true).then(() => { guildsGateway.cache.set(guild.id, { settings }); });
-		});
-		await Promise.all(waitForSync);
+		await Promise.all(
+			this.client.guilds.cache.map(guild => {
+				const settings = guildsGateway.acquire(guild);
+				return settings.sync(true).then(() => { guildsGateway.cache.set(guild.id, { settings }); });
+			})
+		);
 
 		this.client.ready = true;
 

--- a/src/events/onceReady.js
+++ b/src/events/onceReady.js
@@ -21,6 +21,15 @@ module.exports = class extends Event {
 		// Init all the pieces
 		await Promise.all(this.client.pieceStores.filter(store => !['providers', 'extendables'].includes(store.name)).map(store => store.init()));
 		util.initClean(this.client);
+
+		// Initialize guild cache:
+		const guildsGateway = this.client.gateways.get('guilds');
+		const waitForSync = this.client.guilds.cache.map(guild => {
+			const settings = guildsGateway.acquire(guild);
+			return settings.sync(true).then(() => { guildsGateway.cache.set(guild.id, { settings }); });
+		});
+		await Promise.all(waitForSync);
+
 		this.client.ready = true;
 
 		if (this.client.options.readyMessage !== null) {

--- a/src/lib/extensions/KlasaMessage.js
+++ b/src/lib/extensions/KlasaMessage.js
@@ -181,7 +181,7 @@ module.exports = Structures.extend('Message', Message => {
 		 * @private
 		 */
 		_customPrefix() {
-			const settings = this.guild ? this.guild.client.gateways.get('guilds').acquire(this.guild.id) : this.client.gateways.get('guilds').schema.defaults;
+			const settings = this.guild ? this.guild.client.gateways.get('guilds').get(this.guild.id) : this.client.gateways.get('guilds').schema.defaults;
 			if (!settings) return null;
 			const prefix = settings.get('prefix');
 			if (!prefix || !prefix.length) return null;


### PR DESCRIPTION
Preloads the guild cache on startup.

Tested:

- Switching prefix takes effect immediately
- Restarting bot responds immediately to first command in guild with custom prefix
- Default prefix also works immediately.
- Direct messages still work.