### PR TITLE
Fix Klasa bug from last commit

### DIFF
--- a/src/lib/util/util.js
+++ b/src/lib/util/util.js
@@ -298,6 +298,8 @@ class Util {
 		return given;
 	}
 
+}
+
 /**
  * Promisified version of child_process.exec for use with await
  * @since 0.3.0


### PR DESCRIPTION
Last commit you removed an extra `}`, this replaces it so the code doesn't error out.