### PR TITLE
Fix bug with newly joined guilds

### DIFF
--- a/src/events/coreGuildCreate.js
+++ b/src/events/coreGuildCreate.js
@@ -12,6 +12,10 @@ module.exports = class extends Event {
 			guild.leave();
 			this.client.emit('warn', `Blacklisted guild detected: ${guild.name} [${guild.id}]`);
 		}
+		/* Create cache entry for new guild: */
+		const guildsGateway = this.client.gateways.get('guilds');
+		const guildSettings = guildsGateway.acquire(guild);
+		guildSettings.sync(true).then(() => guildsGateway.cache.set(guild.id, { settings: guildSettings }));
 	}
 
 };


### PR DESCRIPTION
Finally figured it out :D yay

Basically just when joining a new guild, we create the cache entry.

Super easy fix for an issue that won't exist when Klasa is gone.